### PR TITLE
feat: add liteLLM agent_base_url parameter

### DIFF
--- a/mcp_claude_code/cli.py
+++ b/mcp_claude_code/cli.py
@@ -56,6 +56,12 @@ def main() -> None:
     )
     
     _ = parser.add_argument(
+        "--agent-base-url",
+        dest="agent_base_url",
+        help="Specify the base URL for the LLM provider API endpoint (e.g., 'http://localhost:1234/v1')"
+    )
+    
+    _ = parser.add_argument(
         "--agent-max-iterations",
         dest="agent_max_iterations",
         type=int,
@@ -94,6 +100,7 @@ def main() -> None:
     agent_model: str | None = cast(str | None, args.agent_model)
     agent_max_tokens: int | None = cast(int | None, args.agent_max_tokens)
     agent_api_key: str | None = cast(str | None, args.agent_api_key)
+    agent_base_url: str | None = cast(str | None, args.agent_base_url)
     agent_max_iterations: int = cast(int, args.agent_max_iterations)
     agent_max_tool_uses: int = cast(int, args.agent_max_tool_uses)
     enable_agent_tool: bool = cast(bool, args.enable_agent_tool)
@@ -116,6 +123,7 @@ def main() -> None:
         agent_model=agent_model,
         agent_max_tokens=agent_max_tokens,
         agent_api_key=agent_api_key,
+        agent_base_url=agent_base_url,
         agent_max_iterations=agent_max_iterations,
         agent_max_tool_uses=agent_max_tool_uses,
         enable_agent_tool=enable_agent_tool

--- a/mcp_claude_code/server.py
+++ b/mcp_claude_code/server.py
@@ -22,6 +22,7 @@ class ClaudeCodeServer:
         agent_model: str | None = None,
         agent_max_tokens: int | None = None,
         agent_api_key: str | None = None,
+        agent_base_url: str | None = None,
         agent_max_iterations: int = 10,
         agent_max_tool_uses: int = 30,
         enable_agent_tool: bool = False,
@@ -35,6 +36,7 @@ class ClaudeCodeServer:
             agent_model: Optional model name for agent tool in LiteLLM format
             agent_max_tokens: Optional maximum tokens for agent responses
             agent_api_key: Optional API key for the LLM provider
+            agent_base_url: Optional base URL for the LLM provider API endpoint
             agent_max_iterations: Maximum number of iterations for agent (default: 10)
             agent_max_tool_uses: Maximum number of total tool uses for agent (default: 30)
             enable_agent_tool: Whether to enable the agent tool (default: False)
@@ -61,6 +63,7 @@ class ClaudeCodeServer:
         self.agent_model = agent_model
         self.agent_max_tokens = agent_max_tokens
         self.agent_api_key = agent_api_key
+        self.agent_base_url = agent_base_url
         self.agent_max_iterations = agent_max_iterations
         self.agent_max_tool_uses = agent_max_tool_uses
         self.enable_agent_tool = enable_agent_tool
@@ -73,6 +76,7 @@ class ClaudeCodeServer:
             agent_model=self.agent_model,
             agent_max_tokens=self.agent_max_tokens,
             agent_api_key=self.agent_api_key,
+            agent_base_url=self.agent_base_url,
             agent_max_iterations=self.agent_max_iterations,
             agent_max_tool_uses=self.agent_max_tool_uses,
             enable_agent_tool=self.enable_agent_tool,

--- a/mcp_claude_code/tools/__init__.py
+++ b/mcp_claude_code/tools/__init__.py
@@ -28,6 +28,7 @@ def register_all_tools(
     agent_model: str | None = None,
     agent_max_tokens: int | None = None,
     agent_api_key: str | None = None,
+    agent_base_url: str | None = None,
     agent_max_iterations: int = 10,
     agent_max_tool_uses: int = 30,
     enable_agent_tool: bool = False,
@@ -41,6 +42,7 @@ def register_all_tools(
         agent_model: Optional model name for agent tool in LiteLLM format
         agent_max_tokens: Optional maximum tokens for agent responses
         agent_api_key: Optional API key for the LLM provider
+        agent_base_url: Optional base URL for the LLM provider API endpoint
         agent_max_iterations: Maximum number of iterations for agent (default: 10)
         agent_max_tool_uses: Maximum number of total tool uses for agent (default: 30)
         enable_agent_tool: Whether to enable the agent tool (default: False)
@@ -64,6 +66,7 @@ def register_all_tools(
             agent_model=agent_model,
             agent_max_tokens=agent_max_tokens,
             agent_api_key=agent_api_key,
+            agent_base_url=agent_base_url,
             agent_max_iterations=agent_max_iterations,
             agent_max_tool_uses=agent_max_tool_uses
         )

--- a/mcp_claude_code/tools/agent/__init__.py
+++ b/mcp_claude_code/tools/agent/__init__.py
@@ -21,6 +21,7 @@ def register_agent_tools(
     agent_model: str | None = None,
     agent_max_tokens: int | None = None,
     agent_api_key: str | None = None,
+    agent_base_url: str | None = None,
     agent_max_iterations: int = 10,
     agent_max_tool_uses: int = 30,
 ) -> list[BaseTool]:
@@ -34,6 +35,7 @@ def register_agent_tools(
         agent_model: Optional model name for agent tool in LiteLLM format
         agent_max_tokens: Optional maximum tokens for agent responses
         agent_api_key: Optional API key for the LLM provider
+        agent_base_url: Optional base URL for the LLM provider API endpoint
         agent_max_iterations: Maximum number of iterations for agent (default: 10)
         agent_max_tool_uses: Maximum number of total tool uses for agent (default: 30)
 
@@ -47,6 +49,7 @@ def register_agent_tools(
         command_executor=command_executor,
         model=agent_model,
         api_key=agent_api_key,
+        base_url=agent_base_url,
         max_tokens=agent_max_tokens,
         max_iterations=agent_max_iterations,
         max_tool_uses=agent_max_tool_uses

--- a/mcp_claude_code/tools/agent/agent_tool.py
+++ b/mcp_claude_code/tools/agent/agent_tool.py
@@ -102,7 +102,7 @@ Returns:
 
     def __init__(
             self, document_context: DocumentContext, permission_manager: PermissionManager, command_executor: CommandExecutor,
-            model: str | None = None, api_key: str | None = None, max_tokens: int | None = None,
+            model: str | None = None, api_key: str | None = None, base_url: str | None = None, max_tokens: int | None = None,
             max_iterations: int = 10, max_tool_uses: int = 30
     ) -> None:
         """Initialize the agent tool.
@@ -113,6 +113,7 @@ Returns:
             command_executor: Command executor for running shell commands
             model: Optional model name override in LiteLLM format (e.g., "openai/gpt-4o")
             api_key: Optional API key for the model provider
+            base_url: Optional base URL for the model provider API endpoint
             max_tokens: Optional maximum tokens for model responses
             max_iterations: Maximum number of iterations for agent (default: 10)
             max_tool_uses: Maximum number of total tool uses for agent (default: 30)
@@ -122,6 +123,7 @@ Returns:
         self.command_executor = command_executor
         self.model_override = model
         self.api_key_override = api_key
+        self.base_url_override = base_url
         self.max_tokens_override = max_tokens
         self.max_iterations = max_iterations
         self.max_tool_uses = max_tool_uses
@@ -283,6 +285,10 @@ Returns:
                 # Add max_tokens if provided
                 if params.get("max_tokens"):
                     completion_params["max_tokens"] = params.get("max_tokens")
+                    
+                # Add base_url if provided
+                if self.base_url_override:
+                    completion_params["base_url"] = self.base_url_override
                 
                 # Make the model call
                 response = litellm.completion(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mcp-claude-code"
 version = "0.1.27"
 description = "MCP implementation of Claude Code capabilities"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "SDGLBL", email = "sdglbl.me@gmail.com" }]
 classifiers = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ class TestCLI:
             mock_args.agent_model = "anthropic/claude-3-sonnet"
             mock_args.agent_max_tokens = 2000
             mock_args.agent_api_key = "test_api_key"
+            mock_args.agent_base_url = None
             mock_args.agent_max_iterations = 10
             mock_args.agent_max_tool_uses = 30
             mock_args.enable_agent_tool = False
@@ -50,6 +51,7 @@ class TestCLI:
                 agent_model="anthropic/claude-3-sonnet",
                 agent_max_tokens=2000,
                 agent_api_key="test_api_key",
+                agent_base_url=None,
                 agent_max_iterations=10,
                 agent_max_tool_uses=30,
                 enable_agent_tool=False
@@ -91,6 +93,7 @@ class TestCLI:
             mock_args.agent_model = None
             mock_args.agent_max_tokens = None
             mock_args.agent_api_key = None
+            mock_args.agent_base_url = None
             mock_args.agent_max_iterations = 10
             mock_args.agent_max_tool_uses = 30
             mock_args.enable_agent_tool = False
@@ -110,6 +113,7 @@ class TestCLI:
                 agent_model=None,
                 agent_max_tokens=None,
                 agent_api_key=None,
+                agent_base_url=None,
                 agent_max_iterations=10,
                 agent_max_tool_uses=30,
                 enable_agent_tool=False


### PR DESCRIPTION
This parameter allows for local llm support. a fake api_key needs to be passed even if unnecessary.

I used this MCP server to make the change, so easy. Then I reviewed/compiled/tested, and it works great with LM Studio!

This resolves https://github.com/SDGLBL/mcp-claude-code/issues/13